### PR TITLE
added family names to appear on the tags on product show page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  before_action :configure_permitted_parameters, if: :devise_controller?
   before_action :authenticate_user!
 
   def configure_permitted_parameters

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -17,12 +17,17 @@
         <li><%= product.material.description %> — <%= product.material.long_description %></li>
         <% end %>
         </p>
+       <% family_description = [] %>
         <div class="tags">
           <% @product.product_materials.each do |product|%>
             <% product.material.material_material_families.each do |family| %>
-            <button class="tag"><i class="fas fa-tag pr-2"></i><%= family.material_family.description %></button>
+              <% family_description.push(family.material_family.description) %>
             <% end %>
           <% end %>
+       <% family_description = family_description.uniq %>
+            <% family_description.each do |description| %>
+               <button class="tag"><i class="fas fa-tag pr-2"></i><%= description %></button>
+            <% end %>
         </div>
         <div class="additional-product-info">
           <div class="upc">
@@ -49,7 +54,7 @@
   </div>
   <div class="py-5">
     <%= link_to "Back to products", products_path, class:"btn-terciary" %>
-    <!-- <i class="fas fa-arrow-left"></i> -->
+    <!-- <i class="fas fa-arrow-left"></i>
   </div>
 </div>
 

--- a/app/views/products/show.html.erb
+++ b/app/views/products/show.html.erb
@@ -18,8 +18,11 @@
         <% end %>
         </p>
         <div class="tags">
-          <button class="tag"><i class="fas fa-tag pr-2"></i>Tag</button>
-          <button class="tag"><i class="fas fa-tag pr-2"></i>Tag</button>
+          <% @product.product_materials.each do |product|%>
+            <% product.material.material_material_families.each do |family| %>
+            <button class="tag"><i class="fas fa-tag pr-2"></i><%= family.material_family.description %></button>
+            <% end %>
+          <% end %>
         </div>
         <div class="additional-product-info">
           <div class="upc">


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/22182095/120741069-5ee99d00-c4c2-11eb-9aa0-34bfe0c3c74d.png)


added family names to appear on the tags on product show page. there are duplicates which i'll fix next. 